### PR TITLE
Fix headings

### DIFF
--- a/docs/reference/policy_templates/receivers.md
+++ b/docs/reference/policy_templates/receivers.md
@@ -18,13 +18,13 @@ or other organizations that receive vulnerability reports.
 
 `ORGANIZATION` SHALL deal in good faith with Reporters who discover, test, and report vulnerabilities or indicators of vulnerabilities in accordance with these guidelines.
 
-## General
+### General
 
 * `ORGANIZATION` MAY modify the terms of this policy or terminate the policy at any time.
 
 * `ORGANIZATION` SHALL use information reported to this program for defensive purposes only; to mitigate or remediate vulnerabilities in our networks or applications, or the applications of our vendors.
 
-## Case handling
+### Case handling
 
 * `ORGANIZATION` MAY, at our discretion, decline to coordinate or publish a vulnerability report. This decision is generally based on the scope and severity of the vulnerability and our ability to add value to the coordination and disclosure process.
 
@@ -36,7 +36,7 @@ or other organizations that receive vulnerability reports.
 
 * `ORGANIZATION` SHALL determine an appropriate timeframe for mitigation development and deployment for vulnerabilities reported in systems it controls.
 
-## Coordination with reporters
+### Coordination with reporters
 
 * `ORGANIZATION` SHALL acknowledge receipt of vulnerability reports via email within `SLC`.
 
@@ -78,13 +78,13 @@ or other organizations that receive vulnerability reports.
 
 * `ORGANIZATION` SHALL act in accordance with the expectations of Reporters set forth in this policy when acting as a Reporter to other organizations (vendors, coordinators, etc.).
 
-## Coordination with others
+### Coordination with others
 
 * `ORGANIZATION` MAY engage the services of a third party coordination service (e.g., CERT/CC, DHS CISA) to assist in resolving any conflicts that cannot be resolved between the Reporter and `ORGANIZATION`.
 
 * `ORGANIZATION` MAY, at our discretion, provide reported vulnerability information to anyone who can contribute to the solution and with whom we have a trusted relationship, including vendors (often including vendors whose products are not vulnerable), service providers, community experts, sponsors, and sites that are part of a national critical infrastructure, if we believe those sites to be at risk.
 
-## Public disclosure
+### Public disclosure
 
 * `ORGANIZATION` SHALL determine the type and schedule of our public disclosure of the vulnerability.
 

--- a/docs/reference/policy_templates/reporters.md
+++ b/docs/reference/policy_templates/reporters.md
@@ -13,13 +13,13 @@ vulnerability disclosure program.<!--end-->
 
 Reporters MUST adhere to the following guidelines.
 
-## General
+### General
 
 * Reporters MUST comply with all applicable `JURISDICTION` laws in connection with security research activities or other participation in this vulnerability disclosure program.
 
 * Reporters SHOULD make a good faith effort to notify and work directly with the affected vendor(s) or service providers prior to publicly disclosing vulnerability reports.
 
-## Scope of Authorized Testing
+### Scope of Authorized Testing
 
 * Reporters MAY test `SYSTEM SCOPE` to detect a vulnerability for the sole purpose of providing `ORGANIZATION` information about that vulnerability.
 
@@ -57,7 +57,7 @@ Reporters MUST adhere to the following guidelines.
 
 * Reporters SHOULD contact `ORGANIZATION` at POINT OF CONTACT if at any point you are uncertain of whether to proceed with testing.
 
-## Coordination with `ORGANIZATION`
+### Coordination with `ORGANIZATION`
 
 * Reporters SHOULD submit vulnerability reports to `ORGANIZATION` via `REPORTING CHANNEL`.
 
@@ -85,17 +85,17 @@ Reporters MUST adhere to the following guidelines.
 
 * Reporters MUST NOT demand compensation in return for reporting vulnerability information reported outside of an explicit bug bounty program.
 
-## Coordination with vendors
+### Coordination with vendors
 
 * In the event that the Reporter finds a vulnerability in a `ORGANIZATION``SYSTEM SCOPE` consequent to a vulnerability in a generally available product or service, the Reporter MAY report the vulnerability to the affected vendor(s), service provider(s), or third party vulnerability coordination service(s) in order to enable the product or service to be fixed.
 
-## Coordination with others
+### Coordination with others
 
 * Reporters MAY engage the services of a third party coordination service (e.g., CERT/CC, DHS CISA) to assist in resolving any conflicts that cannot be resolved between the Reporter and `ORGANIZATION`.
 
 * Reporters SHOULD NOT disclose any details of any extant `ORGANIZATION``SYSTEM SCOPE` vulnerability, or any indicators of vulnerability to any party not already aware at the time the report is submitted to `ORGANIZATION`.
 
-## Public disclosure
+### Public disclosure
 
 * Reporters MAY disclose to the public the prior existence of vulnerabilities already fixed by `ORGANIZATION`, including potentially details of the vulnerability, indicators of vulnerability, or the nature (but not content) of information rendered available by the vulnerability.
 

--- a/docs/reference/policy_templates/reporters.md
+++ b/docs/reference/policy_templates/reporters.md
@@ -87,13 +87,13 @@ Reporters MUST adhere to the following guidelines.
 
 ### Coordination with vendors
 
-* In the event that the Reporter finds a vulnerability in a `ORGANIZATION``SYSTEM SCOPE` consequent to a vulnerability in a generally available product or service, the Reporter MAY report the vulnerability to the affected vendor(s), service provider(s), or third party vulnerability coordination service(s) in order to enable the product or service to be fixed.
+* In the event that the Reporter finds a vulnerability in a `ORGANIZATION` `SYSTEM SCOPE` consequent to a vulnerability in a generally available product or service, the Reporter MAY report the vulnerability to the affected vendor(s), service provider(s), or third party vulnerability coordination service(s) in order to enable the product or service to be fixed.
 
 ### Coordination with others
 
 * Reporters MAY engage the services of a third party coordination service (e.g., CERT/CC, DHS CISA) to assist in resolving any conflicts that cannot be resolved between the Reporter and `ORGANIZATION`.
 
-* Reporters SHOULD NOT disclose any details of any extant `ORGANIZATION``SYSTEM SCOPE` vulnerability, or any indicators of vulnerability to any party not already aware at the time the report is submitted to `ORGANIZATION`.
+* Reporters SHOULD NOT disclose any details of any extant `ORGANIZATION` `SYSTEM SCOPE` vulnerability, or any indicators of vulnerability to any party not already aware at the time the report is submitted to `ORGANIZATION`.
 
 ### Public disclosure
 


### PR DESCRIPTION
This PR adjust the heading levels of the recently added disclosure policy templates 

- `docs/reference/policy_templates/receivers.md`
- `docs/reference/policy_templates/reporters.md`

to be consistent with the intended hierarchy (everything after `## Template Policy Statements` should be an h3 `###` instead of an h2.

Also, incidental to this change:

- resolves #28 
 