### PR TITLE
Replace NVD CVE links with cve.org links

### DIFF
--- a/docs/howto/coordination/hype.md
+++ b/docs/howto/coordination/hype.md
@@ -3,12 +3,12 @@
 !!! example inline end "Branded Vulnerabilities"
 
     In recent years we've witnessed the rise of branded vulnerabilities, including
-    [Heartbleed](https://nvd.nist.gov/vuln/detail/CVE-2014-0160){:target="_blank"},
-    [Poodle](https://nvd.nist.gov/vuln/detail/CVE-2014-3566){:target="_blank"},
-    [Badlock](https://nvd.nist.gov/vuln/detail/CVE-2016-2118){:target="_blank"},
-    [Shell Shock](https://nvd.nist.gov/vuln/detail/CVE-2014-6271){:target="_blank"},
-    [GHOST](https://nvd.nist.gov/vuln/detail/CVE-2015-0235){:target="_blank"},
-    [Spectre and Meltdown](https://nvd.nist.gov/vuln/detail/CVE-2017-5753){:target="_blank"}.
+    [Heartbleed](https://www.cve.org/CVERecord?id=CVE-2014-0160){:target="_blank"},
+    [Poodle](https://www.cve.org/CVERecord?id=CVE-2014-3566){:target="_blank"},
+    [Badlock](https://www.cve.org/CVERecord?id=CVE-2016-2118){:target="_blank"},
+    [Shell Shock](https://www.cve.org/CVERecord?id=CVE-2014-6271){:target="_blank"},
+    [GHOST](https://www.cve.org/CVERecord?id=CVE-2015-0235){:target="_blank"},
+    [Spectre and Meltdown](https://www.cve.org/CVERecord?id=CVE-2017-5753){:target="_blank"}.
 
 <!--start-->Is a branded vulnerability more dangerous than one without?
 Not in any technical sense, no. Instead, what it does is

--- a/docs/howto/coordination/maintaining_secrecy.md
+++ b/docs/howto/coordination/maintaining_secrecy.md
@@ -36,9 +36,9 @@ increases exponentially with the number of parties involved.
 
     Lest you think that $1000$ participants in a case is an unrealistic number, consider that
     in the Apache Log4j case [VU#930724](https://kb.cert.org/vuls/id/930724){:target="_blank"} 
-    ([CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228){:target="_blank"},
-    [CVE-2021-4104](https://nvd.nist.gov/vuln/detail/CVE-2021-4104){:target="_blank"},
-    [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046){:target="_blank"},
+    ([CVE-2021-44228](https://www.cve.org/CVERecord?id=CVE-2021-44228){:target="_blank"},
+    [CVE-2021-4104](https://www.cve.org/CVERecord?id=CVE-2021-4104){:target="_blank"},
+    [CVE-2021-45046](https://www.cve.org/CVERecord?id=CVE-2021-45046){:target="_blank"},
     the CERT/CC notified $1643$ vendors, and we're reasonably certain that we missed more than a few.
 
 !!! tip "Keep Embargoes Short"

--- a/docs/howto/coordination/mpcvd.md
+++ b/docs/howto/coordination/mpcvd.md
@@ -73,7 +73,7 @@ independent discovery of vulnerabilities can and does happen.
     Perhaps the best known example of multiple finders is [Heartbleed](http://heartbleed.com/){:target="_blank"}
     ([CVE-2014-0160](https://nvd.nist.gov/vuln/detail/cve-2014-0160){:target="_blank"}).
     In part because of the complexity of the coordinated disclosure
-    process, a second CVE identifier ([CVE-2014-0346](https://nvd.nist.gov/vuln/detail/CVE-2014-0346){:target="_blank"})
+    process, a second CVE identifier ([CVE-2014-0346](https://www.cve.org/CVERecord?id=CVE-2014-0346){:target="_blank"})
     was assigned to the same vulnerability  and later retracted.
 
 !!! tip "Independent Discovery"


### PR DESCRIPTION
This PR swaps CVE links from NVD to point to cve.org instead. The CVE data at cve.org has improved considerably since the Guide was originally published, so it seems more reasonable to point to it as a canonical source for CVE IDs.