### PR TITLE
docs: fix typo in NIAC Framework title in phases documentation

### DIFF
--- a/docs/topics/phases/index.md
+++ b/docs/topics/phases/index.md
@@ -43,7 +43,7 @@ with more phases to better describe what we have seen at the CERT/CC
     There have been a number of proposed models of the CVD process that have slightly varying phases. Some of the most notable include:
 
     - 2002 Christey and Wysopal [Responsible Vulnerability Disclosure Process](https://datatracker.ietf.org/doc/draft-christey-wysopal-vuln-disclosure/){:target="_blank"}
-    - 2004 National Infrastructure Advisory Council [Vulnerability Disclosure Framweork](https://www.dhs.gov/xlibrary/assets/vdwgreport.pdf){:target="_blank"}
+    - 2004 National Infrastructure Advisory Council [Vulnerability Disclosure Framework](https://www.dhs.gov/xlibrary/assets/vdwgreport.pdf){:target="_blank"}
     - 2018 ISO/IEC 29147:2018 [Information technology -- Security techniques -- Vulnerability disclosure](https://www.iso.org/standard/72311.html){:target="_blank"}
     - 2019 ISO/IEC 30111:2019 [Information technology -- Security techniques -- Vulnerability handling processes](https://www.iso.org/standard/69725.html){:target="_blank"}
 


### PR DESCRIPTION
Corrects the spelling of 'Framweork' to 'Framework' in the NIAC Vulnerability Disclosure Framework title within docs/topics/phases/index.md.

*Contributions to this project are subject to the terms listed in [CONTRIBUTING.md](CONTRIBUTING.md).*
