### PR TITLE
docs: fix markdown parsing issue with underscores in link attributes and italic text

### DIFF
--- a/docs/howto/coordination/maintaining_secrecy.md
+++ b/docs/howto/coordination/maintaining_secrecy.md
@@ -38,7 +38,7 @@ increases exponentially with the number of parties involved.
     in the Apache Log4j case [VU#930724](https://kb.cert.org/vuls/id/930724){:target="_blank"} 
     ([CVE-2021-44228](https://www.cve.org/CVERecord?id=CVE-2021-44228){:target="_blank"},
     [CVE-2021-4104](https://www.cve.org/CVERecord?id=CVE-2021-4104){:target="_blank"},
-    [CVE-2021-45046](https://www.cve.org/CVERecord?id=CVE-2021-45046){:target="_blank"},
+    [CVE-2021-45046](https://www.cve.org/CVERecord?id=CVE-2021-45046){:target="_blank"}),
     the CERT/CC notified $1643$ vendors, and we're reasonably certain that we missed more than a few.
 
 !!! tip "Keep Embargoes Short"

--- a/docs/why_this_guide.md
+++ b/docs/why_this_guide.md
@@ -119,7 +119,7 @@ disclosure of information about software and system vulnerabilities.
     The CERT/CC has already encountered cases where the question of _who owns an algorithm_
     has been a significant factor in the vulnerability coordination process.
 
-    In [VU#425163](https://kb.cert.org/vuls/id/425163){:target="_blank"} _Machine learning classifiers trained via gradient descent are vulnerable to arbitrary misclassification attack_,
+    In [VU#425163](https://kb.cert.org/vuls/id/425163){:target="\_blank"} _Machine learning classifiers trained via gradient descent are vulnerable to arbitrary misclassification attack_,
     we highlighted the fact that all classifiers trained via gradient descent are vulnerable to adversarial examples.
     But with whom should we coordinate to fix this problem? The authors of the paper that defined the gradient descent algorithm?
     While those authors might be interested in following up on the problem in a future paper, they are not the ones who have deployed the algorithm in a system,


### PR DESCRIPTION
The `python-markdown` parser (via `md_in_html` extension) incorrectly handles underscores when a `{:target="_blank"}` attribute is combined with markdown italic text on the same line.

## Current Behavior
In `docs/why_this_guide.md`, lines containing both link attributes and italic text are parsed incorrectly:

```markdown
In [VU#425163]([https://kb.cert.org/vuls/id/425163){:target="_blank"}](https://kb.cert.org/vuls/id/425163)%7B:target=%22_blank%22%7D) _Machine learning classifiers ..._
```
Generates incorrect HTML:
```html
<p>In <a href="[https://kb.cert.org/vuls/id/425163"><abbr](https://kb.cert.org/vuls/id/425163%22%3E%3Cabbr) title="CERT Vulnerability Note">VU#</abbr>425163</a>{:target="<em>blank"} _Machine learning classifiers trained via gradient descent are vulnerable to arbitrary misclassification attack</em>,
```

## Root Cause
The `md_in_html` extension (enabled in `mkdocs.yml`) appears to misinterpret the underscore in `_blank` as a markdown italic marker when it appears before other italic text.

## Solution
Escape the underscore in `_blank` when on the same line as italic text.
```markdown
{:target="\_blank"}
```

## Testing
Parsing comparison available at: https://babelmark.github.io/?text=In+%5BVU%23425163%5D(https%3A%2F%2Fkb.cert.org%2Fvuls%2Fid%2F425163)%7B%3Atarget%3D%22%5C_blank%22%7D+_Machine+learning_%2C%0A%0AIn+%5BVU%23425163%5D(https%3A%2F%2Fkb.cert.org%2Fvuls%2Fid%2F425163)%7B%3Atarget%3D%22_blank%22%7D+_Machine+learning_%2C
note: scroll down to section 2 to view results from `python-markdown`

## Related Configuration
This issue involves the `md_in_html` extension listed under `markdown_extensions` in `mkdocs.yml`, which is likely related to the `mkdocs-material*` requirements.

*Contributions to this project are subject to the terms listed in [CONTRIBUTING.md](CONTRIBUTING.md).*
