### PR TITLE
Removed incomplete citation

### DIFF
--- a/docs/howto/preparation/why_coordinate.md
+++ b/docs/howto/preparation/why_coordinate.md
@@ -96,7 +96,3 @@ avoiding bad press for being unprepared.
     > The new report published today looks into the expectations of both industry and the Member States in relation to 
     > the NIS2’s objective. It also analyses the related legal, collaborative, technical challenges arising from such 
     > initiatives.
-
-    attack frequency increase with vulnerability disclosure? An
-    empirical analysis," *Information Systems Frontiers,* vol. 8, no.
-    5, pp. 350-362, 2006.


### PR DESCRIPTION
Removed incomplete citation (likely leftover from a previous draft). Paper is cited via a link on line 14:
```
Prior research at Carnegie Mellon into [vulnerability disclosure practices](https://doi.org/10.1007/s10796-006-9012-5){:target="_blank"} has shown
```