### PR TITLE
docs: fix incorrect use of CSAF acronym

### DIFF
--- a/docs/reference/simple_advisory.md
+++ b/docs/reference/simple_advisory.md
@@ -12,7 +12,7 @@ needs.
 
 !!! tip "Common Security Advisory Framework"
 
-    The [Common Security Advisory Framework](https://oasis-open.github.io/csaf-documentation/){:target="_blank"} (CSAF) is a standardized 
+    The [Common Security Advisory Framework](https://www.csaf.io){:target="_blank"} (CSAF) is a standardized 
     format for publishing security advisories. It is designed to be machine-readable and is
     intended to be used by vendors, coordinators, and reporters to communicate with the public about vulnerabilities.
 

--- a/docs/reference/simple_advisory.md
+++ b/docs/reference/simple_advisory.md
@@ -10,9 +10,9 @@ It is not meant to be exhaustive of all scenarios.
 Please modify the sections and format as necessary to better suit your
 needs.
 
-!!! tip "Common Security Advisory Format"
+!!! tip "Common Security Advisory Framework"
 
-    The [Common Security Advisory Format](https://oasis-open.github.io/csaf-documentation/){:target="_blank"} (CSAF) is a standardized 
+    The [Common Security Advisory Framework](https://oasis-open.github.io/csaf-documentation/){:target="_blank"} (CSAF) is a standardized 
     format for publishing security advisories. It is designed to be machine-readable and is
     intended to be used by vendors, coordinators, and reporters to communicate with the public about vulnerabilities.
 


### PR DESCRIPTION
In [docs/reference/simple_advisory.md](https://github.com/CERTCC/CERT-Guide-to-CVD/blob/main/docs/reference/simple_advisory.md), CSAF is incorrectly referred to as the "Common Security Advisory Format". The word "Format" should be changed to "Framework" as seen here: https://www.csaf.io/

This pull request changes the two instances found in simple_advisory.md, where "Format" should be changed to "Framework" when referring to the Common Security Advisory Framework (CSAF).
